### PR TITLE
package.json bin section

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "bin",
     "index.js"
   ],
+  "bin": {
+    "exiftool": "./bin/exiftool"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mceachen/exiftool-vendored.pl.git"


### PR DESCRIPTION
It will allow to call exiftool from `./node_modules/.bin/exiftool` in the parent module
https://docs.npmjs.com/files/package.json#bin